### PR TITLE
Simplify provider selection to Claude only

### DIFF
--- a/READM.md
+++ b/READM.md
@@ -1,0 +1,1 @@
+npx http-server src/demoでデモ用のフォームを立ち上げ

--- a/src/options/components/ApiKeyForm.tsx
+++ b/src/options/components/ApiKeyForm.tsx
@@ -14,7 +14,7 @@ interface ApiKeyFormProps {
 
 const ApiKeyForm: React.FC<ApiKeyFormProps> = ({ onSubmit }) => {
   const [apiKey, setApiKey] = useState('');
-  const [provider, setProvider] = useState<'openai' | 'claude'>('openai');
+  const [provider, setProvider] = useState<'openai' | 'claude'>('claude');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [savedApiKey, setSavedApiKey] = useState<ApiKey | null>(null);
@@ -38,12 +38,6 @@ const ApiKeyForm: React.FC<ApiKeyFormProps> = ({ onSubmit }) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-
-    // APIキーの形式を検証
-    if (provider === 'openai' && !apiKey.startsWith('sk-')) {
-      setError('APIキーの形式が正しくありません');
-      return;
-    }
 
     try {
       await saveApiKey({
@@ -113,13 +107,13 @@ const ApiKeyForm: React.FC<ApiKeyFormProps> = ({ onSubmit }) => {
             onChange={handleProviderChange}
             data-testid="llm-provider-select"
           >
-            <MenuItem value="openai">OpenAI</MenuItem>
+            <MenuItem value="claude">Claude</MenuItem>
           </Select>
         </FormControl>
 
         <TextField
           fullWidth
-          label="OpenAI APIキー"
+          label="Claude APIキー"
           type="password"
           value={apiKey}
           onChange={handleApiKeyChange}

--- a/src/options/components/__tests__/ApiKeyForm.test.tsx
+++ b/src/options/components/__tests__/ApiKeyForm.test.tsx
@@ -38,27 +38,9 @@ describe('ApiKeyForm', () => {
       expect(screen.queryByText(/読み込み中/i)).not.toBeInTheDocument();
     });
 
-    const input = screen.getByLabelText(/OpenAI APIキー/i);
+    const input = screen.getByLabelText(/Claude APIキー/i);
     await userEvent.type(input, 'test-api-key');
     expect(input).toHaveValue('test-api-key');
-  });
-
-  it('displays validation error for invalid API key format', async () => {
-    render(<ApiKeyForm />);
-
-    await waitFor(() => {
-      expect(screen.queryByText(/読み込み中/i)).not.toBeInTheDocument();
-    });
-
-    const input = screen.getByLabelText(/OpenAI APIキー/i);
-    const submitButton = screen.getByRole('button', { name: /保存/i });
-
-    await userEvent.type(input, 'invalid-key');
-    await userEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(screen.getAllByText(/APIキーの形式が正しくありません/i)).toHaveLength(2);
-    });
   });
 
   it('handles form submission with valid API key', async () => {
@@ -71,16 +53,16 @@ describe('ApiKeyForm', () => {
       expect(screen.queryByText(/読み込み中/i)).not.toBeInTheDocument();
     });
 
-    const input = screen.getByLabelText(/OpenAI APIキー/i);
+    const input = screen.getByLabelText(/Claude APIキー/i);
     const submitButton = screen.getByRole('button', { name: /保存/i });
 
-    await userEvent.type(input, 'sk-test-valid-key');
+    await userEvent.type(input, 'test-valid-key');
     await userEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockSaveApiKey).toHaveBeenCalledWith({
-        key: 'sk-test-valid-key',
-        provider: 'openai',
+        key: 'test-valid-key',
+        provider: 'claude',
         timestamp: expect.any(String)
       });
     });
@@ -91,8 +73,8 @@ describe('ApiKeyForm', () => {
     const mockDeleteApiKey = deleteApiKey as jest.Mock;
 
     mockGetApiKey.mockResolvedValueOnce({
-      key: 'sk-test-key',
-      provider: 'openai',
+      key: 'test-key',
+      provider: 'claude',
       timestamp: '2025-02-08T13:42:02.468Z'
     });
 
@@ -128,10 +110,10 @@ describe('ApiKeyForm', () => {
       expect(screen.queryByText(/読み込み中/i)).not.toBeInTheDocument();
     });
 
-    const input = screen.getByLabelText(/OpenAI APIキー/i);
+    const input = screen.getByLabelText(/Claude APIキー/i);
     const submitButton = screen.getByRole('button', { name: /保存/i });
 
-    await userEvent.type(input, 'sk-test-valid-key');
+    await userEvent.type(input, 'test-api-key');
     await userEvent.click(submitButton);
 
     await waitFor(() => {
@@ -144,8 +126,8 @@ describe('ApiKeyForm', () => {
     const mockDeleteApiKey = deleteApiKey as jest.Mock;
 
     mockGetApiKey.mockResolvedValueOnce({
-      key: 'sk-test-key',
-      provider: 'openai',
+      key: 'test-key',
+      provider: 'claude',
       timestamp: '2025-02-08T13:42:02.468Z'
     });
 


### PR DESCRIPTION
## 変更内容
- デフォルトのプロバイダーをOpenAIからClaudeに変更
- プルダウンメニューの選択肢をClaudeのみに変更
- APIキー入力フィールドのラベルを「OpenAI APIキー」から「Claude APIキー」に変更
- OpenAI APIキーの形式チェック（sk-で始まる）を削除
- テストコードを新しい実装に合わせて更新

## 将来の拡張性
- 将来的に他のプロバイダーを追加する可能性を考慮し、プルダウンのUIは維持